### PR TITLE
Arreglar archivo ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents:read
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Se agrego un espacio faltante en el archivo ci.yml que provocaba un error en el github actions