### PR TITLE
Corregir usos del ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'temurin'
           java-version: '20'
       - name: Compilar proyecto
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: build
         # generates coverage-report.md and publishes as checkrun jacoco


### PR DESCRIPTION
Se corrigio el uso de compilar proyecto, debiado a un error que generaba.